### PR TITLE
16_AWSテキスト教材一覧ページの実装

### DIFF
--- a/app/controllers/aws_texts_controller.rb
+++ b/app/controllers/aws_texts_controller.rb
@@ -1,0 +1,8 @@
+class AwsTextsController < ApplicationController
+  def index
+    @aws_texts = AwsText.all
+  end
+
+  def show
+  end
+end

--- a/app/javascript/stylesheets/application.scss
+++ b/app/javascript/stylesheets/application.scss
@@ -1,6 +1,5 @@
 @import "~bootstrap/scss/bootstrap";
 
-
 .base-container {
   max-width: 992px;
   margin: 0 auto;
@@ -9,4 +8,9 @@
 
 body {
   padding-top: 56px;
+}
+
+#container {
+  max-width: 600px;
+  margin: 100px auto;
 }

--- a/app/views/aws_texts/index.html.erb
+++ b/app/views/aws_texts/index.html.erb
@@ -1,0 +1,24 @@
+<div id="container">
+  <section id="contents">
+    <div class="text-center">
+      <h4>AWS講座</h4>
+    </div>
+    <p>注意！！！:AWSのEC2やRDSは有料サービスとなります。無駄な料金を請求されないためにも、不要なインスタンスは停止・削除をしてください。</p>
+    <table class="table table-striped">
+      <thead class="aws-table-head text-white">
+        <tr class="table-primary">
+          <th class="w-1">No.</th>
+          <th class="w-5">内容</th>
+        </tr>
+      </thead>
+      <tbody>
+        <% @aws_texts.each.with_index(1) do |aws_text, index| %>
+          <tr>
+            <td><%= index %></td>
+            <td><%= link_to aws_text.title, aws_text, target: "_blank", rel: "noopener" %></td>
+          </tr>
+        <% end %>
+      </tbody>
+    </table>
+  </section>
+</div>

--- a/app/views/aws_texts/show.html.erb
+++ b/app/views/aws_texts/show.html.erb
@@ -1,0 +1,2 @@
+<h1>AwsTexts#show</h1>
+<p>Find me in app/views/aws_texts/show.html.erb</p>

--- a/app/views/layouts/_navbar.html.erb
+++ b/app/views/layouts/_navbar.html.erb
@@ -12,7 +12,7 @@
         <div class="dropdown-menu" aria-labelledby="navbarDropdownMenuLink">
           <%= link_to "Ruby/Rails教材", "#", class: "dropdown-item" %>
           <%= link_to "動画教材", root_path, class: "dropdown-item" %>
-          <%= link_to "AWS講座", "#", class: "dropdown-item" %>
+          <%= link_to "AWS講座", aws_texts_path, class: "dropdown-item" %>
           <%= link_to "ライブコーディング", "#", class: "dropdown-item" %>
           <%= link_to "質問集", "#", class: "dropdown-item" %>
         </div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -4,4 +4,5 @@ Rails.application.routes.draw do
   devise_for :users
   root "movies#index"
   resources :movies, only: [:index]
+  resources :aws_texts, only: [:index, :show]
 end


### PR DESCRIPTION
## 概要
AWSテキスト教材一覧表示ページ作成

## 実装内容
- ルーティング設定
- コントローラ名とアクション名の設定
- 一覧ページの余白調整（css）
- 各AWS教材へのリンク設定
- Bootstrap利用してのスタイル作成

## 参考教材
- Bootstrap 4 フロントエンド開発の教科書
- HTML&CSSとWebデザイン　入門講座
- 逆転教材: HTML基礎／CRUDの実装

## コメント
ご確認をお願いしいます。



