### PR TITLE
17_AWSテキスト教材詳細ページの実装

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -16,6 +16,9 @@ gem 'rails-i18n'
 gem 'devise-i18n'
 gem 'devise-bootstrap-views'
 gem 'activeadmin'
+gem 'redcarpet', '~> 2.3.0'
+gem 'coderay'
+gem 'roo'
 
 group :development, :test do
   gem 'byebug', platforms: [:mri, :mingw, :x64_mingw]

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -202,10 +202,15 @@ GEM
     rb-fsevent (0.10.4)
     rb-inotify (0.10.1)
       ffi (~> 1.0)
+    redcarpet (2.3.0)
     responders (3.0.1)
       actionpack (>= 5.0)
       railties (>= 5.0)
+    roo (2.8.3)
+      nokogiri (~> 1)
+      rubyzip (>= 1.3.0, < 3.0.0)
     ruby_dep (1.5.0)
+    rubyzip (2.3.0)
     sass-rails (6.0.0)
       sassc-rails (~> 2.1, >= 2.1.1)
     sassc (2.4.0)
@@ -259,6 +264,7 @@ DEPENDENCIES
   activeadmin
   bootsnap (>= 1.4.2)
   byebug
+  coderay
   devise
   devise-bootstrap-views
   devise-i18n
@@ -271,6 +277,8 @@ DEPENDENCIES
   puma (~> 4.1)
   rails (~> 6.0.3)
   rails-i18n
+  redcarpet (~> 2.3.0)
+  roo
   sass-rails (>= 6)
   spring
   spring-watcher-listen (~> 2.0.0)

--- a/app/controllers/aws_texts_controller.rb
+++ b/app/controllers/aws_texts_controller.rb
@@ -4,7 +4,6 @@ class AwsTextsController < ApplicationController
   end
 
   def show
-    @aws_texts_title = AwsText.find(params[:id]).title
-    @aws_texts_content = AwsText.find(params[:id]).content
+    @aws_texts = AwsText.find(params[:id])
   end
 end

--- a/app/controllers/aws_texts_controller.rb
+++ b/app/controllers/aws_texts_controller.rb
@@ -4,5 +4,7 @@ class AwsTextsController < ApplicationController
   end
 
   def show
+    @aws_texts_title = AwsText.find(params[:id]).title
+    @aws_texts_content = AwsText.find(params[:id]).content
   end
 end

--- a/app/controllers/aws_texts_controller.rb
+++ b/app/controllers/aws_texts_controller.rb
@@ -4,6 +4,6 @@ class AwsTextsController < ApplicationController
   end
 
   def show
-    @aws_texts = AwsText.find(params[:id])
+    @aws_text = AwsText.find(params[:id])
   end
 end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -1,2 +1,48 @@
 module ApplicationHelper
+    require "redcarpet"
+    require "coderay"
+
+    class HTMLwithCoderay < Redcarpet::Render::HTML
+        def block_code(code, language)
+            language = language.split(':')[0] if language.present?
+
+            case language.to_s
+            when 'rb'
+                lang = :ruby
+            when 'yml'
+                lang = :yaml
+            when 'css'
+                lang = :css
+            when 'html'
+                lang = :html
+            when ''
+                lang = :md
+            else
+                lang = language
+            end
+
+            CodeRay.scan(code, lang).div
+        end
+    end
+
+    def markdown(text)
+        html_render = HTMLwithCoderay.new(
+            filter_html: true,
+            hard_wrap: true,
+            link_attributes: { rel: 'nofollow', target: "_blank" }
+        )
+        options = {
+            autolink: true,
+            space_after_headers: true,
+            no_intra_emphasis: true,
+            fenced_code_blocks: true,
+            tables: true,
+            hard_wrap: true,
+            xhtml: true,
+            lax_html_blocks: true,
+            strikethrough: true
+        }
+        markdown = Redcarpet::Markdown.new(html_render, options)
+        markdown.render(text)
+    end
 end

--- a/app/javascript/stylesheets/application.scss
+++ b/app/javascript/stylesheets/application.scss
@@ -63,3 +63,8 @@ body {
 .card-body {
   height: 250px;
 }
+
+td a:hover{
+  cursor:pointer;
+  color:#34569e !important;
+}

--- a/app/views/aws_texts/index.html.erb
+++ b/app/views/aws_texts/index.html.erb
@@ -5,56 +5,11 @@
     </div>
     <p>注意！！！:AWSのEC2やRDSは有料サービスとなります。無駄な料金を請求されないためにも、不要なインスタンスは停止・削除をしてください。</p>
     <table class="table table-striped">
-      <thead class="aws-table-head text-white">
+    <thead class="aws-table-head text-white">
         <tr class="table-primary">
           <th class="w-1" style="background-color:#5D99FF;">No.</th>
           <th class="w-5" style="background-color:#5D99FF;">内容</th>
         </tr>
-        <tr style="background-color: rgba(0,0,0,0.05);">
-          <td class="w-1" style="color:black;">1</td>
-          <td class="w-5"><%= link_to '【 第1章 】ネットワーク環境設定', 'aws_texts/1' %></td>
-        </tr>
-        <tr>
-          <td class="w-1" style="color:black;">2</td>
-          <td class="w-5"><%= link_to '【 第2章 】RDSの設定', 'aws_texts/2' %></td>
-        </tr>
-        <tr style="background-color: rgba(0,0,0,0.05);">
-          <td class="w-1" style="color:black;">3</td>
-          <td class="w-5"><%= link_to '【 第3章 】EC2の設定', 'aws_texts/3' %></td>
-        </tr>
-        <tr>
-          <td class="w-1" style="color:black;">4</td>
-          <td class="w-5"><%= link_to '【 第4章 】サーバー環境の構築', 'aws_texts/4' %></td>
-        </tr>
-        <tr style="background-color: rgba(0,0,0,0.05);">
-          <td class="w-1" style="color:black;">5</td>
-          <td class="w-5"><%= link_to '【 第5章 】Railsアプリを配置する', 'aws_texts/5' %></td>
-        </tr>
-        <tr>
-          <td class="w-1" style="color:black;">6</td>
-          <td class="w-5"><%= link_to '【 第6章 】ロードバランサーを設定する', 'aws_texts/6' %></td>
-        </tr>
-        <tr style="background-color: rgba(0,0,0,0.05);">
-          <td class="w-1" style="color:black;">7</td>
-          <td class="w-5"><%= link_to '【 第7章 】Railsアプリの起動', 'aws_texts/7' %></td>
-        </tr>
-        <tr>
-          <td class="w-1" style="color:black;">8</td>
-          <td class="w-5"><%= link_to '【 第8章 】ドメインの取得', 'aws_texts/8' %></td>
-        </tr>
-        <tr style="background-color: rgba(0,0,0,0.05);">
-          <td class="w-1" style="color:black;">9</td>
-          <td class="w-5"><%= link_to '【 第9章 】IPアドレスとドメインの関連付け設定', 'aws_texts/9' %></td>
-        </tr>
-        <tr>
-          <td class="w-1" style="color:black;">10</td>
-          <td class="w-5"><%= link_to '【 第10章 】ACMでSSL証明書の取得', 'aws_texts/10' %></td>
-        </tr>
-        <tr style="background-color: rgba(0,0,0,0.05);">
-          <td class="w-1" style="color:black;">11</td>
-          <td class="w-5"><%= link_to '【 第11章 】https化に向けた設定', 'aws_texts/11' %></td>
-        </tr>
-        
       </thead>
       <tbody>
         <% @aws_texts.each.with_index(1) do |aws_text, index| %>

--- a/app/views/aws_texts/index.html.erb
+++ b/app/views/aws_texts/index.html.erb
@@ -7,9 +7,54 @@
     <table class="table table-striped">
       <thead class="aws-table-head text-white">
         <tr class="table-primary">
-          <th class="w-1">No.</th>
-          <th class="w-5">内容</th>
+          <th class="w-1" style="background-color:#5D99FF;">No.</th>
+          <th class="w-5" style="background-color:#5D99FF;">内容</th>
         </tr>
+        <tr style="background-color: rgba(0,0,0,0.05);">
+          <td class="w-1" style="color:black;">1</td>
+          <td class="w-5"><%= link_to '【 第1章 】ネットワーク環境設定', 'aws_texts/1' %></td>
+        </tr>
+        <tr>
+          <td class="w-1" style="color:black;">2</td>
+          <td class="w-5"><%= link_to '【 第2章 】RDSの設定', 'aws_texts/2' %></td>
+        </tr>
+        <tr style="background-color: rgba(0,0,0,0.05);">
+          <td class="w-1" style="color:black;">3</td>
+          <td class="w-5"><%= link_to '【 第3章 】EC2の設定', 'aws_texts/3' %></td>
+        </tr>
+        <tr>
+          <td class="w-1" style="color:black;">4</td>
+          <td class="w-5"><%= link_to '【 第4章 】サーバー環境の構築', 'aws_texts/4' %></td>
+        </tr>
+        <tr style="background-color: rgba(0,0,0,0.05);">
+          <td class="w-1" style="color:black;">5</td>
+          <td class="w-5"><%= link_to '【 第5章 】Railsアプリを配置する', 'aws_texts/5' %></td>
+        </tr>
+        <tr>
+          <td class="w-1" style="color:black;">6</td>
+          <td class="w-5"><%= link_to '【 第6章 】ロードバランサーを設定する', 'aws_texts/6' %></td>
+        </tr>
+        <tr style="background-color: rgba(0,0,0,0.05);">
+          <td class="w-1" style="color:black;">7</td>
+          <td class="w-5"><%= link_to '【 第7章 】Railsアプリの起動', 'aws_texts/7' %></td>
+        </tr>
+        <tr>
+          <td class="w-1" style="color:black;">8</td>
+          <td class="w-5"><%= link_to '【 第8章 】ドメインの取得', 'aws_texts/8' %></td>
+        </tr>
+        <tr style="background-color: rgba(0,0,0,0.05);">
+          <td class="w-1" style="color:black;">9</td>
+          <td class="w-5"><%= link_to '【 第9章 】IPアドレスとドメインの関連付け設定', 'aws_texts/9' %></td>
+        </tr>
+        <tr>
+          <td class="w-1" style="color:black;">10</td>
+          <td class="w-5"><%= link_to '【 第10章 】ACMでSSL証明書の取得', 'aws_texts/10' %></td>
+        </tr>
+        <tr style="background-color: rgba(0,0,0,0.05);">
+          <td class="w-1" style="color:black;">11</td>
+          <td class="w-5"><%= link_to '【 第11章 】https化に向けた設定', 'aws_texts/11' %></td>
+        </tr>
+        
       </thead>
       <tbody>
         <% @aws_texts.each.with_index(1) do |aws_text, index| %>

--- a/app/views/aws_texts/show.html.erb
+++ b/app/views/aws_texts/show.html.erb
@@ -1,2 +1,2 @@
-<h2><%= markdown(@aws_texts.title).html_safe %></h2>
-<%= markdown(@aws_texts.content).html_safe %>
+<h2><%= markdown(@aws_text.title).html_safe %></h2>
+<%= markdown(@aws_text.content).html_safe %>

--- a/app/views/aws_texts/show.html.erb
+++ b/app/views/aws_texts/show.html.erb
@@ -1,2 +1,2 @@
-<h2><%= markdown(@aws_texts_title).html_safe %></h2>
-<%= markdown(@aws_texts_content).html_safe %>
+<h2><%= markdown(@aws_texts.title).html_safe %></h2>
+<%= markdown(@aws_texts.content).html_safe %>

--- a/app/views/aws_texts/show.html.erb
+++ b/app/views/aws_texts/show.html.erb
@@ -1,2 +1,2 @@
-<h1>AwsTexts#show</h1>
-<p>Find me in app/views/aws_texts/show.html.erb</p>
+<h2><%= markdown(@aws_texts_title).html_safe %></h2>
+<%= markdown(@aws_texts_content).html_safe %>

--- a/config/application.rb
+++ b/config/application.rb
@@ -1,3 +1,6 @@
+# require "rails/test_unit/railtie"
+require 'csv'
+
 require_relative 'boot'
 
 require "rails"
@@ -13,7 +16,6 @@ require "action_text/engine"
 require "action_view/railtie"
 require "action_cable/engine"
 require "sprockets/railtie"
-# require "rails/test_unit/railtie"
 
 # Require the gems listed in Gemfile, including any gems
 # you've limited to :test, :development, or :production.
@@ -35,5 +37,3 @@ module GyakutenCloneGroup
   end
 end
 
-require 'rails/all'
-require 'csv'

--- a/config/application.rb
+++ b/config/application.rb
@@ -34,3 +34,6 @@ module GyakutenCloneGroup
     config.generators.system_tests = nil
   end
 end
+
+require 'rails/all'
+require 'csv'

--- a/db/csv_data/aws_text_data.csv
+++ b/db/csv_data/aws_text_data.csv
@@ -1,5 +1,7 @@
 title,content
-【 第1章 】ネットワーク環境設定,"初めにVPC（Virtual Private Cloud）の設定を行っていきましょう！  
+
+## 【 第1章 】ネットワーク環境設定,
+"初めにVPC（Virtual Private Cloud）の設定を行っていきましょう！  
 広いAWSという敷地の中で、自分の領域を決めるというイメージです。
 
 ## 1.VPCの作成

--- a/db/csv_data/aws_text_data.csv
+++ b/db/csv_data/aws_text_data.csv
@@ -1,7 +1,5 @@
 title,content
-
-## 【 第1章 】ネットワーク環境設定,
-"初めにVPC（Virtual Private Cloud）の設定を行っていきましょう！  
+【 第1章 】ネットワーク環境設定,"初めにVPC（Virtual Private Cloud）の設定を行っていきましょう！  
 広いAWSという敷地の中で、自分の領域を決めるというイメージです。
 
 ## 1.VPCの作成


### PR DESCRIPTION
一覧ページの「内容」から詳細ページに移動できるようにしました。詳細ページのMarkDownの導入にも挑戦しました。

コメントをいただきたい点が2点あります。
「タイトルがMarkdownにより<h2>にならないのと、コードの部分が見本の通りになりません。

タイトルの部分においては
```ruby:qiita.rb
<h2><%= markdown(@aws_texts_title).html_safe %></h2>
```
以上のように表記しました。
この点に関しては色々と調べたのですが他に方法がわかりませんでした。

コードの部分に関してはTrelloに「コード表示のスタイルはデフォルトで良い」と書いてありましたが、現状でよろしいのでしょうか？
また、コードにMarkDownを反映させるにはどのような対応が必要なのでしょうか？
「MarkDown 一部エラー」「MarkDown コード」など調べてもわからなかったのでアドバイスいただきたいです。